### PR TITLE
chore(compose): add custom network 'bookstore_net'

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,14 @@
+﻿version: "3.9"
+
+services:
+  web:
+    networks:
+      - bookstore_net
+  db:
+    networks:
+      - bookstore_net
+
+networks:
+  bookstore_net:
+    name: bookstore_net    # evita prefixo do diretório no nome da rede
+    driver: bridge


### PR DESCRIPTION
Adiciona docker-compose.override.yml com a network bookstore_net

Conecta serviços web e db à nova rede

Sem impactos no fluxo atual; override só complementa o compose padrão