### PR TITLE
Adiciona Docker Compose com rede dedicada (bookstore_net) e guia de execução

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+__pycache__
+*.pyc
+env/
+db.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+﻿FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential libpq-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /code
+COPY . /code/
+
+RUN pip install --no-cache-dir poetry && poetry config virtualenvs.create false && poetry lock --no-interaction --no-ansi && poetry install --no-interaction --no-ansi
+
+EXPOSE 8000
+CMD ["python","manage.py","runserver","0.0.0.0:8000"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,14 +1,18 @@
-﻿version: "3.9"
-
-services:
+﻿services:
   web:
     networks:
       - bookstore_net
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+
   db:
     networks:
       - bookstore_net
+    ports: []          
 
 networks:
   bookstore_net:
-    name: bookstore_net    # evita prefixo do diretório no nome da rede
+    name: bookstore_net
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+﻿services:
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_DB: bookstore
+      POSTGRES_USER: bookstore
+      POSTGRES_PASSWORD: bookstore
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bookstore -d bookstore"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  web:
+    build: .
+    ports:
+      - "8000"  # host aleatório -> container 8000
+    environment:
+      SQL_ENGINE: django.db.backends.postgresql
+      SQL_DATABASE: bookstore
+      SQL_USER: bookstore
+      SQL_PASSWORD: bookstore
+      SQL_HOST: db
+      SQL_PORT: "5432"
+      GIT_PYTHON_REFRESH: "quiet"
+    depends_on:
+      db:
+        condition: service_healthy
+    command: >
+      sh -c "python manage.py migrate &&
+             python manage.py runserver 0.0.0.0:8000"
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
<img width="2370" height="1782" alt="image" src="https://github.com/user-attachments/assets/001b2131-05ad-4e41-8297-573a24cb2667" />


Este PR coloca o projeto para rodar via Docker Compose com uma rede bridge dedicada (bookstore_net).
O serviço web (Django) e o db (Postgres) comunicam-se apenas pela rede interna; o banco não é exposto ao host.
Inclui healthcheck do Postgres e depends_on para iniciar o Django apenas após o DB ficar saudável.

Como executar

Pré-requisitos: Docker Desktop (Compose v2).

# 1) Clonar e entrar no projeto (ou usar o link deste PR)
git clone https://github.com/MrPantufa/projeto_bookstore.git
cd projeto_bookstore
git checkout feat/compose-network   # (se estiver testando a partir do branch)

# 2) Subir os containers
docker compose up -d --build

# 3) Verificar status (db saudável e web “Up”)
docker compose ps

# 4) Testar a aplicação
# Linux/macOS:
curl http://localhost:8000/hello/
# Windows (PowerShell):
Invoke-WebRequest http://localhost:8000/hello/ -UseBasicParsing


Esperado: resposta HTTP 200 com a página “Hello, World!”.

Como parar
docker compose down -v

O que foi incluído

docker-compose.yml (serviços web e db, rede bookstore_net, healthcheck e depends_on)

docker-compose.override.yml (exposição do web em 8000:8000)

Dockerfile (build da app)

.dockerignore (exclusões de build)

Sem mudanças de dependências (Poetry) e sem exposição do Postgres ao host — apenas via rede interna do Compose.