### PR TITLE
Docker Compose + Network: ajustar build com Poetry e Postgres (inclui pyproject.toml)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-﻿FROM python:3.10-slim
+FROM python:3.10-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential libpq-dev && rm -rf /var/lib/apt/lists/*
+# system deps for psycopg2
+RUN apt-get update && apt-get install -y --no-install-recommends     build-essential libpq-dev &&     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
+
+# copy project
 COPY . /code/
 
-RUN pip install --no-cache-dir poetry && poetry config virtualenvs.create false && poetry lock --no-interaction --no-ansi && poetry install --no-interaction --no-ansi
+# install poetry and deps (no venv)
+RUN pip install --no-cache-dir poetry &&     poetry config virtualenvs.create false &&     poetry lock --no-interaction --no-ansi &&     poetry install --no-interaction --no-ansi
 
-EXPOSE 8000
-CMD ["python","manage.py","runserver","0.0.0.0:8000"]
+# The command is provided by docker-compose (migrate + runserver)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,21 @@
-﻿services:
+version: "3.9"
+
+services:
   db:
     image: postgres:13
     environment:
       POSTGRES_DB: bookstore
       POSTGRES_USER: bookstore
       POSTGRES_PASSWORD: bookstore
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bookstore -d bookstore"]
+      test: ["CMD-SHELL","pg_isready -U bookstore -d bookstore"]
       interval: 5s
       timeout: 5s
       retries: 10
+    networks: [bookstore_net]
 
   web:
     build: .
-    ports:
-      - "8000"  # host aleatório -> container 8000
     environment:
       SQL_ENGINE: django.db.backends.postgresql
       SQL_DATABASE: bookstore
@@ -31,6 +30,12 @@
     command: >
       sh -c "python manage.py migrate &&
              python manage.py runserver 0.0.0.0:8000"
+    ports:
+      - "8000:8000"
+    networks: [bookstore_net]
 
-volumes:
-  postgres_data:
+networks:
+  bookstore_net:
+    name: bookstore_net
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "bookstore"
+version = "0.1.0"
+description = "Django bookstore with Postgres and Docker Compose"
+authors = ["Mateus <you@example.com>"]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "^3.10"
+Django = "3.2.8"
+djangorestframework = "^3.15.0"
+psycopg2-binary = "^2.9.8"
+gunicorn = "^20.1.0"
+whitenoise = "^5.3.0"
+django-extensions = "^3.1.3"
+django-debug-toolbar = "^3.2.2"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^6.2.5"
+factory-boy = "^3.2.0"
+flake8 = "^4.0.1"
+isort = "^5.10.1"
+
+[build-system]
+requires = ["poetry-core>=2.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Este PR implementa o exercício de Docker Network com Docker Compose para o projeto bookstore e corrige o ponto do feedback (ausência do pyproject.toml, que impedia o build com Poetry).

O que foi feito

pyproject.toml + poetry.lock adicionados (dependências do projeto).

Dockerfile baseado em python:3.10-slim, instala Poetry (sem venv) e prepara a app.

docker-compose.yml com 2 serviços:

db: postgres:13 com healthcheck (pg_isready).

web: build da app, variáveis de ambiente para o Postgres e depends_on com service_healthy; comando executa migrate e depois runserver.

bookstore/settings.py: configuração de banco dinâmica por variáveis de ambiente; usa Postgres quando SQL_ENGINE=django.db.backends.postgresql, senão faz fallback para SQLite.

DRF e Token Auth permanecem habilitados (como no projeto).

Como validar (local)
# subir tudo
docker compose up -d --build

# criar superusuário (após containers subirem)
docker compose exec -it web python manage.py createsuperuser --username mateus --email mateus@example.com


Acessar http://localhost:8000/admin/
 e logar com o superusuário criado.

Critérios do exercício atendidos

Projeto sobe via Docker Compose com rede de containers (web ↔ db via hostname db).

Healthcheck do Postgres e dependência do web aguardando DB saudável.

Build com Poetry funcionando (feedback do professor resolvido ao incluir pyproject.toml).

Aplicação acessível em http://localhost:8000/
 (admin em /admin/) e migrações executadas no start.

Observações

O Compose cria automaticamente uma rede isolada para os serviços; o container web chega no db pelo nome do serviço (db:5432), cobrindo o tópico de Docker Network do módulo.